### PR TITLE
fix: set webpack config resolve.mainFields defaults to [browser, main…

### DIFF
--- a/src/build/createWebpackConfig.ts
+++ b/src/build/createWebpackConfig.ts
@@ -249,7 +249,8 @@ export default function createWebpackConfig(
     maxEntrypointSize: 400000,
     ...config.performance,
   }
-  const resolveConfig = {
+  const resolveConfig: webpack.Resolve = {
+    mainFields: ['browser', 'main'],
     modules: ['node_modules'],
     extensions: ['.js', '.jsx', '.json', '.mjs', '.ts', '.tsx'],
     alias: alias,


### PR DESCRIPTION
修改 webpack 配置的 resolve.mainFields 指定为 ['browser', 'main']，避免引入 esm 模块引发的问题